### PR TITLE
save system data to localStorage in edit mode

### DIFF
--- a/components/System.js
+++ b/components/System.js
@@ -592,7 +592,7 @@ export function System({ownerDocData = {},
         {renderAuthor()}
 
         <div className="System-title">
-          <Title title={system.title} viewOnly={viewOnly} onGetTitle={handleGetTitle} />
+          <Title title={systemLoaded ? system.title : systemDocData.title} viewOnly={viewOnly} onGetTitle={handleGetTitle} />
         </div>
 
         {!isNew && renderSocial()}
@@ -663,9 +663,9 @@ export function System({ownerDocData = {},
           {timeElem}
         </div>
 
-        {(!viewOnly || system.caption) && (
+        {(!viewOnly || (systemLoaded ? system.caption : systemDocData.caption)) && (
           <div className="System-caption">
-            <Description description={system.caption ? system.caption : ''}
+            <Description description={(systemLoaded ? system.caption : systemDocData.caption) ?? ''}
                         viewOnly={viewOnly}
                         placeholder={'Add a caption...'}
                         onDescriptionBlur={handleSetCaption} />
@@ -719,15 +719,15 @@ export function System({ownerDocData = {},
 
             {renderFadeWrap(renderAlert(), 'alert')}
 
-            {!systemLoaded && system.systemIsTrimmed && (
+            {!systemLoaded && system.systemIsTrimmed && viewOnly && (
               <div className="System-loadingNotice Ellipsis">
                 Loading huge map
               </div>
             )}
 
-            {!systemLoaded && !system.systemIsTrimmed && (
+            {!systemLoaded && (!system.systemIsTrimmed || !viewOnly) && (
               <div className="System-loadingNotice Ellipsis">
-                Settings things up
+                Setting things up
               </div>
             )}
           </div>

--- a/pages/edit/new.js
+++ b/pages/edit/new.js
@@ -22,7 +22,7 @@ export async function getServerSideProps({ params, query }) {
     if (query.fromDefault) {
       systemFromBranch = await getSystemFromBranch(query.fromDefault, true);
     } else if (query.fromSystem) {
-      systemFromBranch = await getSystemFromBranch(query.fromSystem, false, true);
+      systemFromBranch = await getSystemFromBranch(query.fromSystem, false, { trimLargeSystems: true });
       newFromSystemId = query.fromSystem;
     }
   } catch (e) {

--- a/pages/view/[systemId].js
+++ b/pages/view/[systemId].js
@@ -55,13 +55,13 @@ export async function getServerSideProps({ req, params }) {
       if (ownerUid && systemNumStr) {
         // TODO: make a promise group for these
         const systemDocData = await getSystemDocData(systemId) ?? null;
-        const fullSystem = await getFullSystem(systemId, true) ?? null;
+        const fullSystem = await getFullSystem(systemId, { trimLargeSystems: true }) ?? null;
 
         if (!systemDocData || !fullSystem || !fullSystem.meta) {
           return { notFound: true };
         }
 
-        if (!('numModes' in systemDocData)) {
+        if (!('numModes' in systemDocData) && fullSystem?.map?.lines) {
           const modeSet = new Set();
           for (const line of Object.values(fullSystem?.map?.lines ?? {})) {
             modeSet.add(line.mode ? line.mode : DEFAULT_LINE_MODE);
@@ -176,7 +176,7 @@ export default function View({
         return updatedSystem;
       });
 
-      const bigSystemData = await getFullSystem(systemId, false);
+      const bigSystemData = await getFullSystem(systemId);
       if (bigSystemData.map) {
         systemFromData = { ...bigSystemData.map };
       } else {

--- a/util/hooks.js
+++ b/util/hooks.js
@@ -231,10 +231,16 @@ export function useSystemDocData({ systemId, initialSystemDocData, noUpdates = f
     if (systemId && !noUpdates) {
       unsubSystem = onSnapshot(doc(firebaseContext.database, `systems/${systemId}`), (docSnap) => {
         if (docSnap.exists()) {
-          setSystemDocData(currData => ({
-            numModes: currData?.numModes, // numModes is generated in SSR in some cases so don't clear it
-            ...docSnap.data()
-          }));
+          setSystemDocData(currData => {
+            if ('numModes' in currData) {
+              return {
+                numModes: currData.numModes, // numModes is generated in SSR in some cases so don't clear it
+                ...docSnap.data()
+              }
+            } else {
+              return docSnap.data();
+            }
+          });
         }
       });
     }


### PR DESCRIPTION
 * allows users to retrieve in progress systems if they close the browser or encouter a runtime error
 * avoids stale data from firebase propagation delays if a user quickly refreshses after saving