### PR TITLE
Add 300ms debounce on name fetching to ease color name API calling

### DIFF
--- a/components/Line.js
+++ b/components/Line.js
@@ -12,7 +12,8 @@ import {
   getLuminance,
   getMode,
   stationIdsToCoordinates,
-  trimStations
+  trimStations,
+  debounce,
 } from '/util/helpers.js';
 import {
   COLOR_TO_NAME,
@@ -99,7 +100,7 @@ export class Line extends React.Component {
       action: 'Show Color Picker'
     });
 
-    fetch(`${COLOR_API_URL}?values=${this.props.line.color.replace('#', '')}&list=wikipedia`)
+    debounce(fetch(`${COLOR_API_URL}?values=${this.props.line.color.replace('#', '')}&list=wikipedia`)
       .then(response => response.json())
       .then(colorJson => {
         if (colorJson && colorJson.paletteTitle) {
@@ -111,7 +112,8 @@ export class Line extends React.Component {
       .catch(e => {
         console.log('getColorName error:', e);
         this.setState({ existingColorName: null });
-      });
+      }), 300
+    );
   }
 
   handleColorSelect(chosen) {

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -1448,3 +1448,16 @@ export function renderSpinner(additionalClass) {
     </div>
   );
 }
+
+
+export function debounce(func, delay) {
+  let timeoutId;
+  return function (...args) {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(() => {
+      func.apply(this, args);
+    }, delay);
+  };
+}


### PR DESCRIPTION
Hey there! Thanks so much for using the Color Name API. Recently, I've noticed a significant increase in calls coming from your site, which led me to temporarily spin up more dynos to handle the load. To help ease the server strain, I've added a brief debounce to limit the frequency of requests.

If you have any questions or need support, feel free to reach out. Thanks again for your understanding and for being part of the community!