### PR TITLE
Add different line thickness options + dashed line option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Dev environment
+.vscode

--- a/components/Line.js
+++ b/components/Line.js
@@ -19,11 +19,13 @@ import {
 import {
   COLOR_TO_NAME,
   DEFAULT_LINE_MODE,
+  DEFAULT_LINE_THICKNESS,
   DEFAULT_LINES,
   FOCUS_ANIM_TIME,
   GEOSPATIAL_API_BASEURL,
   LINE_ICON_SHAPES,
   LINE_MODES,
+  LINE_THICKNESSES,
   MILES_TO_KMS_MULTIPLIER,
 } from '/util/constants.js';
 
@@ -108,8 +110,13 @@ export class Line extends React.Component {
 
     line.color = chosen.color;
 
-    if (this.state.iconName) line.icon = this.state.iconName;
-    else delete line.icon;
+    if (this.state.iconName) {
+      line.icon = this.state.iconName;
+      // dash and icon patterns are mutually exclusive
+      delete line.dashed;
+    } else {
+      delete line.icon;
+    }
 
     this.props.onLineInfoChange(line, true);
 
@@ -139,6 +146,44 @@ export class Line extends React.Component {
         label: option.value
       });
     }
+  }
+
+  handleThicknessChange(option) {
+    let line = this.props.line;
+    const current = line.thickness || DEFAULT_LINE_THICKNESS;
+    if (current !== option.value) {
+      // omit the field when default to keep line documents clean and migrate-safe
+      if (option.value && option.value !== DEFAULT_LINE_THICKNESS) line.thickness = option.value;
+      else delete line.thickness;
+      this.props.onLineInfoChange(line, true);
+
+      ReactGA.event({
+        category: 'Edit',
+        action: 'Change Line Thickness',
+        label: option.value
+      });
+    }
+  }
+
+  handleDashToggle() {
+    if (this.props.viewOnly) return;
+
+    let line = this.props.line;
+    if (line.dashed) {
+      delete line.dashed;
+    } else {
+      line.dashed = true;
+      // dash and icon patterns are mutually exclusive
+      delete line.icon;
+      this.setState({ iconName: null });
+    }
+    this.props.onLineInfoChange(line, true);
+
+    ReactGA.event({
+      category: 'Edit',
+      action: 'Toggle Line Dash',
+      label: line.dashed ? 'on' : 'off'
+    });
   }
 
   handleIconChange(option) {
@@ -650,6 +695,53 @@ export class Line extends React.Component {
     );
   }
 
+  renderThicknessDropdown() {
+    const thicknesses = LINE_THICKNESSES.map(t => {
+      return {
+        label: t.label,
+        value: t.key
+      };
+    });
+
+    return (
+      <div className="Line-thicknessSelect">
+        <Dropdown disabled={this.props.viewOnly} options={thicknesses}
+                  value={this.props.line.thickness || DEFAULT_LINE_THICKNESS}
+                  placeholder="Select a thickness" className="Line-dropdown"
+                  onChange={(thickness) => this.handleThicknessChange(thickness)} />
+        <i className="far fa-question-circle"
+           data-tooltip-content="Line thickness changes how wide the line is drawn on the map">
+        </i>
+      </div>
+    );
+  }
+
+  renderDashToggle() {
+    const isDashed = !!this.props.line.dashed;
+
+    if (this.props.viewOnly) {
+      if (!isDashed) return;
+      return (
+        <div className="Line-dashToggle Line-dashToggle--viewOnly">
+          <span className="Line-dashToggleLabel">Dashed line</span>
+        </div>
+      );
+    }
+
+    return (
+      <div className="Line-dashToggle">
+        <button className={`Line-dashButton Link${isDashed ? ' Line-dashButton--on' : ''}`}
+                onClick={() => this.handleDashToggle()}>
+          <i className={`fas ${isDashed ? 'fa-check-square' : 'fa-square'}`}></i>
+          Dashed line
+        </button>
+        <i className="far fa-question-circle"
+           data-tooltip-content="Dashed lines are drawn as a dashed pattern over a darker shade of the line color">
+        </i>
+      </div>
+    );
+  }
+
   renderGroupDropdown() {
     if (!this.props.line.lineGroupId && this.props.viewOnly) return;
 
@@ -762,13 +854,15 @@ export class Line extends React.Component {
         </div>
       );
 
-      // height of travel time + mode + each mode option + group + 4
-      const minHeight = this.props.viewOnly ? null : `${20 + 50 + (LINE_MODES.length * 36) + 70 + 4}px`;
+      // height of travel time + mode + each mode option + thickness + dash + group + 4
+      const minHeight = this.props.viewOnly ? null : `${20 + 50 + (LINE_MODES.length * 36) + 50 + 40 + 70 + 4}px`;
 
       return (
         <div className="Line-details" style={{ minHeight }}>
           {this.renderStats()}
           {this.renderModeDropdown()}
+          {this.renderThicknessDropdown()}
+          {this.renderDashToggle()}
           {this.renderGroupDropdown()}
           {this.props.viewOnly || this.props.line.stationIds.length < 2 ? '' : reverseWrap}
           {this.props.viewOnly || this.props.line.stationIds.length < 2 ? '' : duplicateWrap}

--- a/components/Line.js
+++ b/components/Line.js
@@ -9,6 +9,7 @@ import {
   displayLargeNumber,
   divideLineSections,
   getLineColorIconStyle,
+  getLinePattern,
   getLuminance,
   getMode,
   getNameForCustomColor,
@@ -19,12 +20,14 @@ import {
 import {
   COLOR_TO_NAME,
   DEFAULT_LINE_MODE,
+  DEFAULT_LINE_PATTERN,
   DEFAULT_LINE_THICKNESS,
   DEFAULT_LINES,
   FOCUS_ANIM_TIME,
   GEOSPATIAL_API_BASEURL,
   LINE_ICON_SHAPES,
   LINE_MODES,
+  LINE_PATTERNS,
   LINE_THICKNESSES,
   MILES_TO_KMS_MULTIPLIER,
 } from '/util/constants.js';
@@ -112,8 +115,9 @@ export class Line extends React.Component {
 
     if (this.state.iconName) {
       line.icon = this.state.iconName;
-      // dash and icon patterns are mutually exclusive
-      delete line.dashed;
+      // icon patterns and stroke patterns (dashed, ...) are mutually exclusive
+      delete line.pattern;
+      delete line.dashed; // legacy field
     } else {
       delete line.icon;
     }
@@ -165,24 +169,27 @@ export class Line extends React.Component {
     }
   }
 
-  handleDashToggle() {
-    if (this.props.viewOnly) return;
-
+  handlePatternChange(option) {
     let line = this.props.line;
-    if (line.dashed) {
-      delete line.dashed;
-    } else {
-      line.dashed = true;
-      // dash and icon patterns are mutually exclusive
+    if (getLinePattern(line) === option.value) return;
+
+    // omit the field when default to keep line documents clean and migrate-safe
+    if (option.value && option.value !== DEFAULT_LINE_PATTERN) line.pattern = option.value;
+    else delete line.pattern;
+    delete line.dashed; // drop legacy boolean once the enum field is set
+
+    // icon patterns and stroke patterns are mutually exclusive
+    if (line.pattern) {
       delete line.icon;
       this.setState({ iconName: null });
     }
+
     this.props.onLineInfoChange(line, true);
 
     ReactGA.event({
       category: 'Edit',
-      action: 'Toggle Line Dash',
-      label: line.dashed ? 'on' : 'off'
+      action: 'Change Line Pattern',
+      label: option.value
     });
   }
 
@@ -716,27 +723,29 @@ export class Line extends React.Component {
     );
   }
 
-  renderDashToggle() {
-    const isDashed = !!this.props.line.dashed;
+  renderPatternDropdown() {
+    const currentPattern = getLinePattern(this.props.line);
 
-    if (this.props.viewOnly) {
-      if (!isDashed) return;
-      return (
-        <div className="Line-dashToggle Line-dashToggle--viewOnly">
-          <span className="Line-dashToggleLabel">Dashed line</span>
-        </div>
-      );
-    }
+    // icon patterns and stroke patterns are mutually exclusive; while an icon is
+    // set the icon IS the pattern, so hide this control to avoid contradiction
+    if (this.props.line.icon) return;
+    if (this.props.viewOnly && currentPattern === DEFAULT_LINE_PATTERN) return;
+
+    const patterns = LINE_PATTERNS.map(p => {
+      return {
+        label: p.label,
+        value: p.key
+      };
+    });
 
     return (
-      <div className="Line-dashToggle">
-        <button className={`Line-dashButton Link${isDashed ? ' Line-dashButton--on' : ''}`}
-                onClick={() => this.handleDashToggle()}>
-          <i className={`fas ${isDashed ? 'fa-check-square' : 'fa-square'}`}></i>
-          Dashed line
-        </button>
+      <div className="Line-patternSelect">
+        <Dropdown disabled={this.props.viewOnly} options={patterns}
+                  value={currentPattern}
+                  placeholder="Select a pattern" className="Line-dropdown"
+                  onChange={(pattern) => this.handlePatternChange(pattern)} />
         <i className="far fa-question-circle"
-           data-tooltip-content="Dashed lines are drawn as a dashed pattern over a darker shade of the line color">
+           data-tooltip-content="Line pattern changes how the stroke is drawn (e.g. dashed reveals a darker shade of the color in the gaps)">
         </i>
       </div>
     );
@@ -854,15 +863,15 @@ export class Line extends React.Component {
         </div>
       );
 
-      // height of travel time + mode + each mode option + thickness + dash + group + 4
-      const minHeight = this.props.viewOnly ? null : `${20 + 50 + (LINE_MODES.length * 36) + 50 + 40 + 70 + 4}px`;
+      // height of travel time + mode + each mode option + thickness + pattern + group + 4
+      const minHeight = this.props.viewOnly ? null : `${20 + 50 + (LINE_MODES.length * 36) + 50 + 50 + 70 + 4}px`;
 
       return (
         <div className="Line-details" style={{ minHeight }}>
           {this.renderStats()}
           {this.renderModeDropdown()}
           {this.renderThicknessDropdown()}
-          {this.renderDashToggle()}
+          {this.renderPatternDropdown()}
           {this.renderGroupDropdown()}
           {this.props.viewOnly || this.props.line.stationIds.length < 2 ? '' : reverseWrap}
           {this.props.viewOnly || this.props.line.stationIds.length < 2 ? '' : duplicateWrap}

--- a/components/Map.js
+++ b/components/Map.js
@@ -18,7 +18,10 @@ import {
   stationIdsToMultiLineCoordinates,
   floatifyStationCoord,
   getLineIconPath,
-  getColoredIcon
+  getColoredIcon,
+  getThicknessMult,
+  darkenColor,
+  patternKey
 } from '/util/helpers.js';
 import { useMapbox } from '../util/mapProvider.js';
 
@@ -422,6 +425,11 @@ export function Map({ system,
       // the switch between highlight and color/icon. This enables the ability to have
       // the transitions only take up a total of one fourth of the loop duration.
 
+      // scale the focus line to the line's thickness, and dash it if the line is dashed
+      const focusColorWidth = 12 * getThicknessMult(focus.line.thickness);
+      const focusIsDashed = !!focus.line.dashed && !getColoredIcon(focus.line);
+      const focusDashArray = (focusBeat >= 4 && focusIsDashed) ? [2, 2] : [1, 0];
+
       if (existingLayer) {
         let existingSource = map.getSource(focusLayerId);
         if (existingSource && existingSource._data && existingSource._data.properties &&
@@ -432,8 +440,9 @@ export function Map({ system,
           const highlightColor = getUseLight() ? '#000000' : '#ffffff';
           map.setPaintProperty(existingLayer.id, 'line-pattern', focusBeat < 4 ? '' : getColoredIcon(focus.line));
           map.setPaintProperty(existingLayer.id, 'line-color', focusBeat < 4 ? highlightColor : focus.line.color);
-          map.setPaintProperty(existingLayer.id, 'line-width', focusBeat < 4 ? 4 : 12);
-          map.setPaintProperty(existingLayer.id, 'line-gap-width', focusBeat < 4 ? 12 : 0);
+          map.setPaintProperty(existingLayer.id, 'line-width', focusBeat < 4 ? 4 : focusColorWidth);
+          map.setPaintProperty(existingLayer.id, 'line-gap-width', focusBeat < 4 ? focusColorWidth : 0);
+          map.setPaintProperty(existingLayer.id, 'line-dasharray', focusDashArray);
           map.setPaintProperty(existingLayer.id, 'line-opacity', focusBeat === 3 || focusBeat === 7 ? 0 : 1);
 
           map.moveLayer(existingLayer.id);
@@ -455,8 +464,8 @@ export function Map({ system,
             'type': 'geojson'
           },
           'paint': {
-            'line-width': focusBeat < 4 ? 4 : 12,
-            'line-gap-width': focusBeat < 4 ? 12 : 0,
+            'line-width': focusBeat < 4 ? 4 : focusColorWidth,
+            'line-gap-width': focusBeat < 4 ? focusColorWidth : 0,
             'line-opacity-transition': { duration: FOCUS_ANIM_TIME / 2 }
           }
         };
@@ -464,6 +473,7 @@ export function Map({ system,
         const highlightColor = getUseLight() ? '#000000' : '#ffffff';
         layer.paint['line-pattern'] = focusBeat < 4 ? '' : getColoredIcon(focus.line);
         layer.paint['line-color'] = focusBeat < 4 ? highlightColor : focus.line.color;
+        layer.paint['line-dasharray'] = focusDashArray;
         layer.paint['line-opacity'] = focusBeat === 3 || focusBeat === 7 ? 0 : 1;
 
         renderLayer(focusLayerId, layer, focusFeature);
@@ -514,13 +524,19 @@ export function Map({ system,
   useEffect(() => {
     let solidSegments = [];
     let iconSegments = [];
+    let dashSegments = [];
     for (const segmentFeat of segmentFeats) {
       if (segmentFeat.properties?.icon) {
         iconSegments.push(segmentFeat);
+      } else if (segmentFeat.properties?.dashed) {
+        dashSegments.push(segmentFeat);
       } else {
         solidSegments.push(segmentFeat);
       }
     }
+
+    // base render width is 8px; per-feature widthMult scales it for thin/thick lines
+    const segmentWidth = ['*', 8, ['get', 'widthMult']];
 
     const layerIDSolid = 'js-Map-segments--solid';
     const layerSolid = {
@@ -534,7 +550,7 @@ export function Map({ system,
         "type": "geojson"
       },
       "paint": {
-        "line-width": 8,
+        "line-width": segmentWidth,
         "line-offset": ['get', 'offset'],
         "line-color": ['get', 'color']
       }
@@ -556,7 +572,7 @@ export function Map({ system,
         "type": "geojson"
       },
       "paint": {
-        "line-width": 8,
+        "line-width": segmentWidth,
         "line-offset": ['get', 'offset'],
         "line-pattern": ['get', 'icon']
       }
@@ -567,8 +583,55 @@ export function Map({ system,
       "features": iconSegments
     };
 
+    // dashed lines are drawn as two stacked layers: a solid darker underlay,
+    // and the primary color dashed on top so the gaps reveal the darker color.
+    // line-dasharray units are in line-widths, so a fixed array scales with thickness.
+    const layerIDDashUnder = 'js-Map-segments--dashUnder';
+    const layerDashUnder = {
+      "type": "line",
+      "layout": {
+        "line-join": "miter",
+        "line-cap": "butt",
+        "line-sort-key": 2
+      },
+      "source": {
+        "type": "geojson"
+      },
+      "paint": {
+        "line-width": segmentWidth,
+        "line-offset": ['get', 'offset'],
+        "line-color": ['get', 'dashColor']
+      }
+    };
+
+    const layerIDDashOver = 'js-Map-segments--dashOver';
+    const layerDashOver = {
+      "type": "line",
+      "layout": {
+        "line-join": "miter",
+        "line-cap": "butt",
+        "line-sort-key": 2
+      },
+      "source": {
+        "type": "geojson"
+      },
+      "paint": {
+        "line-width": segmentWidth,
+        "line-offset": ['get', 'offset'],
+        "line-color": ['get', 'color'],
+        "line-dasharray": [2, 2]
+      }
+    };
+
+    let featCollectionDash = {
+      "type": "FeatureCollection",
+      "features": dashSegments
+    };
+
     renderLayer(layerIDSolid, layerSolid, featCollectionSolid, 'js-Map-stations');
     renderLayer(layerIDIcon, layerIcon, featCollectionIcon, 'js-Map-stations');
+    renderLayer(layerIDDashUnder, layerDashUnder, featCollectionDash, 'js-Map-stations');
+    renderLayer(layerIDDashOver, layerDashOver, featCollectionDash, 'js-Map-stations');
 
     touchUpperMapLayers();
   }, [segmentFeats]);
@@ -1426,7 +1489,15 @@ export function Map({ system,
     for (const segmentKey of segmentsBeingHandled) {
       if (!(segmentKey in interlineSegments)) {
         for (const lineKey of Object.keys(lines)) {
-          updatedSegmentFeatures[segmentKey + '|' + lines[lineKey].color + '|' + getColoredIcon(lines[lineKey], 'solid')] = {};
+          const line = lines[lineKey];
+          const coloredIcon = getColoredIcon(line, 'solid');
+          const lineLongkey = patternKey({
+            color: line.color,
+            icon: coloredIcon,
+            widthMult: getThicknessMult(line.thickness),
+            dashed: !!line.dashed && coloredIcon === 'solid'
+          });
+          updatedSegmentFeatures[segmentKey + '|' + lineLongkey] = {};
         }
         continue;
       }
@@ -1435,39 +1506,34 @@ export function Map({ system,
       const coords = stationIdsToMultiLineCoordinates(stations, segment.stationIds);
 
       for (const pattern of segment.patterns) {
+        const longkey = segmentKey + '|' + patternKey(pattern);
+        const widthMult = pattern.widthMult != null ? pattern.widthMult : 1;
+
+        let properties = {
+          "segment-key": segmentKey,
+          "segment-longkey": longkey,
+          "widthMult": widthMult,
+          "offset": segment.offsets[patternKey(pattern)]
+        };
+
         if (pattern.icon) {
-          const data = {
-            "type": "Feature",
-            "properties": {
-              "segment-key": segmentKey,
-              "segment-longkey": segmentKey + '|' + pattern.color + '|' + pattern.icon,
-              "icon": pattern.icon,
-              "offset": segment.offsets[`${pattern.color}|${pattern.icon}`]
-            },
-            "geometry": {
-              "type": "MultiLineString",
-              "coordinates": coords
-            }
-          }
-
-          updatedSegmentFeatures[segmentKey + '|' + pattern.color + '|' + pattern.icon] = data;
+          properties.icon = pattern.icon;
+        } else if (pattern.dashed) {
+          properties.color = pattern.color;
+          properties.dashColor = darkenColor(pattern.color);
+          properties.dashed = true;
         } else {
-          const data = {
-            "type": "Feature",
-            "properties": {
-              "segment-key": segmentKey,
-              "segment-longkey": segmentKey + '|' + pattern.color + '|solid',
-              "color": pattern.color,
-              "offset": segment.offsets[`${pattern.color}|${pattern.icon ? pattern.icon : 'solid'}`]
-            },
-            "geometry": {
-              "type": "MultiLineString",
-              "coordinates": coords
-            }
-          }
-
-          updatedSegmentFeatures[segmentKey + '|' + pattern.color + '|solid'] = data;
+          properties.color = pattern.color;
         }
+
+        updatedSegmentFeatures[longkey] = {
+          "type": "Feature",
+          "properties": properties,
+          "geometry": {
+            "type": "MultiLineString",
+            "coordinates": coords
+          }
+        };
       }
     }
 
@@ -1488,10 +1554,7 @@ export function Map({ system,
             if (segKey in interlineSegments) {
               let isStillPresent = false;
               for (const pattern of (interlineSegments[segKey].patterns || [])) {
-                if (feat.properties['icon'] && pattern.icon && feat.properties['icon'] === pattern.icon) {
-                  isStillPresent = true;
-                  break;
-                } else if (!feat.properties['icon'] && !pattern.icon && feat.properties['color'] === pattern.color) {
+                if (feat.properties['segment-longkey'] === segKey + '|' + patternKey(pattern)) {
                   isStillPresent = true;
                   break;
                 }

--- a/components/Map.js
+++ b/components/Map.js
@@ -20,7 +20,9 @@ import {
   getLineIconPath,
   getColoredIcon,
   getThicknessMult,
-  darkenColor,
+  getLinePattern,
+  getLineStyle,
+  getSecondaryColor,
   patternKey
 } from '/util/helpers.js';
 import { useMapbox } from '../util/mapProvider.js';
@@ -427,7 +429,7 @@ export function Map({ system,
 
       // scale the focus line to the line's thickness, and dash it if the line is dashed
       const focusColorWidth = 12 * getThicknessMult(focus.line.thickness);
-      const focusIsDashed = !!focus.line.dashed && !getColoredIcon(focus.line);
+      const focusIsDashed = getLinePattern(focus.line) === 'DASHED' && !getColoredIcon(focus.line);
       const focusDashArray = (focusBeat >= 4 && focusIsDashed) ? [2, 2] : [1, 0];
 
       if (existingLayer) {
@@ -528,7 +530,7 @@ export function Map({ system,
     for (const segmentFeat of segmentFeats) {
       if (segmentFeat.properties?.icon) {
         iconSegments.push(segmentFeat);
-      } else if (segmentFeat.properties?.dashed) {
+      } else if (segmentFeat.properties?.pattern === 'DASHED') {
         dashSegments.push(segmentFeat);
       } else {
         solidSegments.push(segmentFeat);
@@ -600,7 +602,7 @@ export function Map({ system,
       "paint": {
         "line-width": segmentWidth,
         "line-offset": ['get', 'offset'],
-        "line-color": ['get', 'dashColor']
+        "line-color": ['get', 'secondaryColor']
       }
     };
 
@@ -1489,14 +1491,7 @@ export function Map({ system,
     for (const segmentKey of segmentsBeingHandled) {
       if (!(segmentKey in interlineSegments)) {
         for (const lineKey of Object.keys(lines)) {
-          const line = lines[lineKey];
-          const coloredIcon = getColoredIcon(line, 'solid');
-          const lineLongkey = patternKey({
-            color: line.color,
-            icon: coloredIcon,
-            widthMult: getThicknessMult(line.thickness),
-            dashed: !!line.dashed && coloredIcon === 'solid'
-          });
+          const lineLongkey = patternKey(getLineStyle(lines[lineKey]));
           updatedSegmentFeatures[segmentKey + '|' + lineLongkey] = {};
         }
         continue;
@@ -1518,10 +1513,10 @@ export function Map({ system,
 
         if (pattern.icon) {
           properties.icon = pattern.icon;
-        } else if (pattern.dashed) {
+        } else if (pattern.pattern === 'DASHED') {
           properties.color = pattern.color;
-          properties.dashColor = darkenColor(pattern.color);
-          properties.dashed = true;
+          properties.secondaryColor = getSecondaryColor({ color: pattern.color, secondaryColor: pattern.secondaryColor });
+          properties.pattern = 'DASHED';
         } else {
           properties.color = pattern.color;
         }

--- a/components/ResultMap.js
+++ b/components/ResultMap.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import mapboxgl from 'mapbox-gl';
 
 import { COLOR_TO_NAME, FLY_TIME, LINE_ICON_SHAPE_SET } from '/util/constants.js';
-import { getLineIconPath, stationIdsToMultiLineCoordinates } from '/util/helpers.js';
+import { getLineIconPath, stationIdsToMultiLineCoordinates, patternKey, darkenColor } from '/util/helpers.js';
 import { useMapbox } from '/util/mapProvider.js';
 
 import MapSlot from '/components/MapSlot.js';
@@ -121,13 +121,19 @@ export function ResultMap(props) {
   useEffect(() => {
     let solidSegments = [];
     let iconSegments = [];
+    let dashSegments = [];
     for (const segmentFeat of segmentFeats) {
       if (segmentFeat.properties?.icon) {
         iconSegments.push(segmentFeat);
+      } else if (segmentFeat.properties?.dashed) {
+        dashSegments.push(segmentFeat);
       } else {
         solidSegments.push(segmentFeat);
       }
     }
+
+    // base render width is 4px on mini-maps; per-feature widthMult scales it
+    const segmentWidth = ['*', 4, ['get', 'widthMult']];
 
     const layerIDSolid = 'js-Map-segments--solid';
     const layerSolid = {
@@ -141,7 +147,7 @@ export function ResultMap(props) {
         "type": "geojson"
       },
       "paint": {
-        "line-width": 4,
+        "line-width": segmentWidth,
         "line-offset": ['get', 'offset'],
         "line-color": ['get', 'color']
       }
@@ -163,7 +169,7 @@ export function ResultMap(props) {
         "type": "geojson"
       },
       "paint": {
-        "line-width": 4,
+        "line-width": segmentWidth,
         "line-offset": ['get', 'offset'],
         "line-pattern": ['get', 'icon']
       }
@@ -174,8 +180,53 @@ export function ResultMap(props) {
       "features": iconSegments
     };
 
+    // dashed lines: solid darker underlay with the primary color dashed on top
+    const layerIDDashUnder = 'js-Map-segments--dashUnder';
+    const layerDashUnder = {
+      "type": "line",
+      "layout": {
+        "line-join": "miter",
+        "line-cap": "square",
+        "line-sort-key": 1
+      },
+      "source": {
+        "type": "geojson"
+      },
+      "paint": {
+        "line-width": segmentWidth,
+        "line-offset": ['get', 'offset'],
+        "line-color": ['get', 'dashColor']
+      }
+    };
+
+    const layerIDDashOver = 'js-Map-segments--dashOver';
+    const layerDashOver = {
+      "type": "line",
+      "layout": {
+        "line-join": "miter",
+        "line-cap": "square",
+        "line-sort-key": 1
+      },
+      "source": {
+        "type": "geojson"
+      },
+      "paint": {
+        "line-width": segmentWidth,
+        "line-offset": ['get', 'offset'],
+        "line-color": ['get', 'color'],
+        "line-dasharray": [2, 2]
+      }
+    };
+
+    let featCollectionDash = {
+      "type": "FeatureCollection",
+      "features": dashSegments
+    };
+
     renderLayer(layerIDSolid, layerSolid, featCollectionSolid);
     renderLayer(layerIDIcon, layerIcon, featCollectionIcon);
+    renderLayer(layerIDDashUnder, layerDashUnder, featCollectionDash);
+    renderLayer(layerIDDashOver, layerDashOver, featCollectionDash);
   }, [segmentFeats]);
 
   // Handle context lost by marking style as not loaded; provider owns map lifecycle
@@ -226,23 +277,31 @@ export function ResultMap(props) {
       const coords = stationIdsToMultiLineCoordinates(stations, segment.stationIds);
 
       for (const pattern of segment.patterns) {
-        const iconName = pattern.icon ? pattern.icon : 'solid';
-        const data = {
+        const longkey = segmentKey + '|' + patternKey(pattern);
+        const widthMult = pattern.widthMult != null ? pattern.widthMult : 1;
+
+        let properties = {
+          "segment-key": segmentKey,
+          "segment-longkey": longkey,
+          "color": pattern.color,
+          "icon": pattern.icon,
+          "widthMult": widthMult,
+          "offset": segment.offsets[patternKey(pattern)]
+        };
+
+        if (!pattern.icon && pattern.dashed) {
+          properties.dashColor = darkenColor(pattern.color);
+          properties.dashed = true;
+        }
+
+        updatedSegmentFeatures[longkey] = {
           "type": "Feature",
-          "properties": {
-            "segment-key": segmentKey,
-            "segment-longkey": segmentKey + '|' + pattern.color + '|' + iconName,
-            "color": pattern.color,
-            "icon": pattern.icon,
-            "offset": segment.offsets[`${pattern.color}|${iconName}`]
-          },
+          "properties": properties,
           "geometry": {
             "type": "MultiLineString",
             "coordinates": coords
           }
-        }
-
-        updatedSegmentFeatures[segmentKey + '|' + pattern.color + '|' + iconName] = data;
+        };
       }
     }
 
@@ -264,10 +323,7 @@ export function ResultMap(props) {
             if (segKey in interlineSegments) {
               let isStillPresent = false;
               for (const pattern of (interlineSegments[segKey].patterns || [])) {
-                if (feat.properties['icon'] && pattern.icon && feat.properties['icon'] === pattern.icon) {
-                  isStillPresent = true;
-                  break;
-                } else if (!feat.properties['icon'] && !pattern.icon && feat.properties['color'] === pattern.color) {
+                if (feat.properties['segment-longkey'] === segKey + '|' + patternKey(pattern)) {
                   isStillPresent = true;
                   break;
                 }

--- a/components/ResultMap.js
+++ b/components/ResultMap.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import mapboxgl from 'mapbox-gl';
 
 import { COLOR_TO_NAME, FLY_TIME, LINE_ICON_SHAPE_SET } from '/util/constants.js';
-import { getLineIconPath, stationIdsToMultiLineCoordinates, patternKey, darkenColor } from '/util/helpers.js';
+import { getLineIconPath, stationIdsToMultiLineCoordinates, patternKey, getSecondaryColor } from '/util/helpers.js';
 import { useMapbox } from '/util/mapProvider.js';
 
 import MapSlot from '/components/MapSlot.js';
@@ -125,7 +125,7 @@ export function ResultMap(props) {
     for (const segmentFeat of segmentFeats) {
       if (segmentFeat.properties?.icon) {
         iconSegments.push(segmentFeat);
-      } else if (segmentFeat.properties?.dashed) {
+      } else if (segmentFeat.properties?.pattern === 'DASHED') {
         dashSegments.push(segmentFeat);
       } else {
         solidSegments.push(segmentFeat);
@@ -195,7 +195,7 @@ export function ResultMap(props) {
       "paint": {
         "line-width": segmentWidth,
         "line-offset": ['get', 'offset'],
-        "line-color": ['get', 'dashColor']
+        "line-color": ['get', 'secondaryColor']
       }
     };
 
@@ -289,9 +289,9 @@ export function ResultMap(props) {
           "offset": segment.offsets[patternKey(pattern)]
         };
 
-        if (!pattern.icon && pattern.dashed) {
-          properties.dashColor = darkenColor(pattern.color);
-          properties.dashed = true;
+        if (!pattern.icon && pattern.pattern === 'DASHED') {
+          properties.secondaryColor = getSecondaryColor({ color: pattern.color, secondaryColor: pattern.secondaryColor });
+          properties.pattern = 'DASHED';
         }
 
         updatedSegmentFeatures[longkey] = {

--- a/styles/scss/components/Line.scss
+++ b/styles/scss/components/Line.scss
@@ -77,7 +77,9 @@
 
   &-modeSelect,
   &-groupSelect,
-  &-iconSelect
+  &-iconSelect,
+  &-thicknessSelect,
+  &-dashToggle
   {
     display: flex;
     align-items: center;
@@ -86,6 +88,18 @@
     i
     {
       margin-left: $gutter/2;
+    }
+  }
+
+  &-dashButton
+  {
+    display: flex;
+    align-items: center;
+
+    i
+    {
+      margin-left: 0;
+      margin-right: $gutter/2;
     }
   }
 

--- a/styles/scss/components/Line.scss
+++ b/styles/scss/components/Line.scss
@@ -79,7 +79,7 @@
   &-groupSelect,
   &-iconSelect,
   &-thicknessSelect,
-  &-dashToggle
+  &-patternSelect
   {
     display: flex;
     align-items: center;
@@ -88,18 +88,6 @@
     i
     {
       margin-left: $gutter/2;
-    }
-  }
-
-  &-dashButton
-  {
-    display: flex;
-    align-items: center;
-
-    i
-    {
-      margin-left: 0;
-      margin-right: $gutter/2;
     }
   }
 

--- a/util/constants.js
+++ b/util/constants.js
@@ -76,6 +76,38 @@ export const INITIAL_META = {
   systemNumStr: '0'
 };
 
+export const DEFAULT_LINE_THICKNESS = 'MEDIUM';
+// line thickness presets; multiplier is applied to the base render width
+// (8px on the editor map, 4px on result mini-maps). MEDIUM = 1 keeps the
+// current default behavior, so lines without a `thickness` render unchanged.
+export const LINE_THICKNESSES = [
+  {
+    key: 'EXTRA_THIN',
+    label: 'Extra Thin',
+    multiplier: 0.25 // 2px / 1px
+  },
+  {
+    key: 'THIN',
+    label: 'Thin',
+    multiplier: 0.625 // 5px on editor map, 2.5px on mini-map
+  },
+  {
+    key: 'MEDIUM',
+    label: 'Medium',
+    multiplier: 1 // 8px / 4px (current default)
+  },
+  {
+    key: 'THICK',
+    label: 'Thick',
+    multiplier: 1.5 // 12px / 6px
+  },
+  {
+    key: 'EXTRA_THICK',
+    label: 'Extra Thick',
+    multiplier: 1.75 // 14px / 7px
+  }
+];
+
 export const DEFAULT_LINE_MODE = 'RAPID';
 export const LINE_MODES = [
   {

--- a/util/constants.js
+++ b/util/constants.js
@@ -102,9 +102,29 @@ export const LINE_THICKNESSES = [
     multiplier: 1.5 // 12px / 6px
   },
   {
+    key: 'VERY_THICK',
+    label: 'Very Thick',
+    multiplier: 1.75 // 14px / 7px
+  },
+  {
     key: 'EXTRA_THICK',
     label: 'Extra Thick',
-    multiplier: 1.75 // 14px / 7px
+    multiplier: 2 // 16px / 8px
+  },
+];
+
+export const DEFAULT_LINE_PATTERN = 'SOLID';
+// line stroke patterns. SOLID is the default, so lines without a `pattern`
+// field render unchanged. New designs (e.g. OUTLINED, LADDERED, STRIPED) can be
+// added here and given a render branch without any data migration.
+export const LINE_PATTERNS = [
+  {
+    key: 'SOLID',
+    label: 'Solid'
+  },
+  {
+    key: 'DASHED',
+    label: 'Dashed'
   }
 ];
 

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -7,7 +7,7 @@ import { lineString as turfLineString } from '@turf/helpers';
 import turfLineIntersect from "@turf/line-intersect";
 
 import {
-  LINE_MODES, DEFAULT_LINE_MODE, LINE_THICKNESSES, USER_ICONS, COLOR_TO_FILTER, SYSTEM_LEVELS, COLOR_TO_NAME, DEFAULT_LINES,
+  LINE_MODES, DEFAULT_LINE_MODE, LINE_THICKNESSES, DEFAULT_LINE_PATTERN, USER_ICONS, COLOR_TO_FILTER, SYSTEM_LEVELS, COLOR_TO_NAME, DEFAULT_LINES,
   ACCESSIBLE, BICYCLE, BUS, CITY, CLOUD, FERRY,
   GONDOLA, METRO, PEDESTRIAN, SHUTTLE, TRAIN, TRAM, USER_BASIC, LINE_ICONS_PNG_DIR,
   LINE_ICON_SHAPE_SET, LINE_ICONS_SVG_DIR
@@ -591,16 +591,60 @@ export function getColoredIcon(line, fallback = '') {
   return coloredIcon;
 }
 
-// builds the visual-identity key for a line/pattern. lines sharing this key
+// resolves the secondary color used by multi-color patterns (e.g. the color
+// revealed in the gaps of a dashed line). defaults to a darker shade of the
+// primary color; honors an explicit `secondaryColor` when one is set.
+export function getSecondaryColor(line = {}) {
+  return line.secondaryColor || darkenColor(line.color);
+}
+
+// resolves a line's stroke pattern key (SOLID, DASHED, ...). defaults to SOLID
+// and falls back to the legacy boolean `dashed` field for maps saved before the
+// pattern enum existed.
+export function getLinePattern(line = {}) {
+  if (line.pattern) return line.pattern;
+  if (line.dashed) return 'DASHED';
+  return DEFAULT_LINE_PATTERN;
+}
+
+// resolves the full render style for an entire line into a single object the
+// render pipeline consumes. centralizing this here means new style fields
+// (custom secondary color, new patterns, ...) only change this one place.
+export function getLineStyle(line = {}, ignoreIcon = false) {
+  const coloredIcon = ignoreIcon ? 'solid' : getColoredIcon(line, 'solid');
+  // icon patterns and stroke patterns (dashed, ...) are mutually exclusive;
+  // an icon line always uses a solid stroke.
+  const pattern = coloredIcon !== 'solid' ? DEFAULT_LINE_PATTERN : getLinePattern(line);
+  return {
+    color: line.color,
+    icon: coloredIcon,
+    widthMult: getThicknessMult(line.thickness),
+    pattern,
+    secondaryColor: getSecondaryColor(line)
+  };
+}
+
+// resolves the render style for the span of a line between two adjacent
+// stations. today this is always the line-level style; the commented seam is
+// where a future per-segment override (line.segmentStyles, keyed by station
+// pair) would be merged on top — making per-segment styling a purely additive
+// change with no impact on existing maps or the rest of the pipeline.
+export function getSegmentStyle(line = {}, fromStationId, toStationId, ignoreIcon = false) {
+  // const override = line.segmentStyles?.[[fromStationId, toStationId].sort().join('|')];
+  // if (override) return getLineStyle({ ...line, ...override }, ignoreIcon);
+  return getLineStyle(line, ignoreIcon);
+}
+
+// builds the visual-identity key for a resolved style. lines sharing this key
 // merge into a single drawn stroke; differing keys render as parallel strokes
-// with their own offset. encodes color, icon, thickness multiplier, and dash
-// so thickness/dash differences produce visually distinct lines.
-// `pattern` accepts { color, icon, widthMult, dashed }.
-export function patternKey(pattern = {}) {
-  const icon = pattern.icon ? pattern.icon : 'solid';
-  const widthMult = pattern.widthMult != null ? pattern.widthMult : 1;
-  const dash = pattern.dashed ? 'dash' : 'nodash';
-  return `${pattern.color}|${icon}|${widthMult}|${dash}`;
+// with their own offset. encodes color, icon, thickness multiplier, and stroke
+// pattern so any of those differing produces a visually distinct line.
+// accepts a style object { color, icon, widthMult, pattern }.
+export function patternKey(style = {}) {
+  const icon = style.icon ? style.icon : 'solid';
+  const widthMult = style.widthMult != null ? style.widthMult : 1;
+  const pattern = style.pattern || DEFAULT_LINE_PATTERN;
+  return `${style.color}|${icon}|${widthMult}|${pattern}`;
 }
 
 // check if the two target stationIds appear adjacent to one another in target line
@@ -640,11 +684,6 @@ function _buildMiniInterlineSegments(lineKeys, system, ignoreIcon) {
   for (const lineKey of lineKeys) {
     const line = system.lines[lineKey];
 
-    const coloredIcon = ignoreIcon ? 'solid' : getColoredIcon(line, 'solid');
-    const lineWidthMult = getThicknessMult(line.thickness);
-    const lineDashed = !!line.dashed && coloredIcon === 'solid'; // dash only applies to non-icon lines
-    const linePattern = patternKey({ color: line.color, icon: coloredIcon, widthMult: lineWidthMult, dashed: lineDashed });
-
     if (!line || !line.stationIds?.length) continue;
 
     for (let i = 0; i < line.stationIds.length - 1; i++) {
@@ -657,6 +696,9 @@ function _buildMiniInterlineSegments(lineKeys, system, ignoreIcon) {
       const nextStation = floatifyStationCoord(system.stations[nextStationId]);
 
       if (!currStation || !nextStation) continue;
+
+      // resolved per-segment so a line can vary its appearance between stations
+      const linePattern = patternKey(getSegmentStyle(line, currStationId, nextStationId, ignoreIcon));
 
       miniInterlineSegments[segmentKey] = {
         stationIds: [currStationId, nextStationId],
@@ -672,10 +714,7 @@ function _buildMiniInterlineSegments(lineKeys, system, ignoreIcon) {
         if (!lineKeyBeingChecked || !system.lines[lineKeyBeingChecked] || !lineKeySet.has(lineKeyBeingChecked)) continue;
 
         const lineBeingChecked = system.lines[lineKeyBeingChecked];
-        const lineBeingCheckedPatternedIcon = ignoreIcon ? 'solid' : getColoredIcon(lineBeingChecked, 'solid');
-        const lineBeingCheckedWidthMult = getThicknessMult(lineBeingChecked.thickness);
-        const lineBeingCheckedDashed = !!lineBeingChecked.dashed && lineBeingCheckedPatternedIcon === 'solid';
-        const lineBeingCheckedPattern = patternKey({ color: lineBeingChecked.color, icon: lineBeingCheckedPatternedIcon, widthMult: lineBeingCheckedWidthMult, dashed: lineBeingCheckedDashed });
+        const lineBeingCheckedPattern = patternKey(getSegmentStyle(lineBeingChecked, currStationId, nextStationId, ignoreIcon));
 
         if (linePattern !== lineBeingCheckedPattern) { // don't bother checking lines with the same color
           let patternsInSegment = [ linePattern ];
@@ -773,14 +812,14 @@ function _accumulateInterlineSegments(miniInterlineSegmentsByColors, thickness, 
       let colors = colorsJoined.split('-');
       let colorConfigs = [];
       for (const [ind, color] of colors.entries()) {
-        // each token is `color|icon|widthMult|dashFlag` (see patternKey)
+        // each token is `color|icon|widthMult|pattern` (see patternKey)
         const colorParts = color.split('|');
         const config = { color: colorParts[0] };
         if (colorParts[1] && colorParts[1] !== 'solid' && !ignoreIcon) {
           config.icon = colorParts[1];
         }
         config.widthMult = colorParts[2] != null && colorParts[2] !== '' ? parseFloat(colorParts[2]) : 1;
-        config.dashed = colorParts[3] === 'dash';
+        config.pattern = colorParts[3] || DEFAULT_LINE_PATTERN;
         colorConfigs.push(config);
       }
       accumulator = accumulator[0] > accumulator[accumulator.length - 1] ? accumulator : [...accumulator].reverse();

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -742,28 +742,38 @@ function _buildMiniInterlineSegments(lineKeys, system, ignoreIcon) {
   return miniInterlineSegments;
 }
 
-// calculate how far a color in an interlineSegment should be shifted left or right
+// calculate how far each line in an interlineSegment should be shifted left or
+// right so that parallel lines sit snug against one another — touching but not
+// overlapping — even when they have different thicknesses. adjacent lines are
+// separated center-to-center by the average of their two widths, and the whole
+// bundle is centered on the shared path.
 function _calculateOffsets(patterns, thickness) {
-  let offsets = {};
-  const centered = patterns.length % 2 === 1; // center if odd number of lines
-  let moveNegative = false;
+  const offsets = {};
+  const n = patterns.length;
+  if (!n) return offsets;
 
-  // widen the spacing unit to the thickest line in the segment so thicker
-  // parallel lines don't overlap. when every line is the default width this
-  // equals `thickness`, leaving existing maps' offsets unchanged.
-  const maxMult = Math.max(1, ...patterns.map(p => p.widthMult != null ? p.widthMult : 1));
-  const displacement = thickness * maxMult;
+  // rendered width of a line = base thickness * its thickness multiplier
+  const widthOf = (pattern) => thickness * (pattern.widthMult != null ? pattern.widthMult : 1);
 
-  for (const [ind, pattern] of patterns.entries()) {
-    let offsetDistance = 0;
-    if (centered) {
-      offsetDistance = Math.floor((ind + 1) / 2) * displacement;
-    } else {
-      offsetDistance = (displacement / 2) + (Math.floor((ind) / 2) * displacement);
-    }
+  // left-to-right placement order. odd indices fan out to the left (descending)
+  // and even indices to the right (ascending), reproducing the prior arrangement
+  // so that when all lines share a thickness the layout is byte-for-byte unchanged
+  // (snug spacing with equal widths == the old uniform spacing).
+  const order = [];
+  for (let i = n - 1; i >= 0; i--) {
+    if (i % 2 === 1) order.push(i);
+  }
+  for (let i = 0; i < n; i++) {
+    if (i % 2 === 0) order.push(i);
+  }
 
-    offsets[patternKey(pattern)] = offsetDistance * (moveNegative ? -1 : 1);
-    moveNegative = !moveNegative;
+  const totalWidth = order.reduce((sum, i) => sum + widthOf(patterns[i]), 0);
+
+  let cursor = -totalWidth / 2; // left edge of the bundle, centered on the path
+  for (const i of order) {
+    const width = widthOf(patterns[i]);
+    offsets[patternKey(patterns[i])] = cursor + (width / 2); // center of this line
+    cursor += width;
   }
 
   return offsets;

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -7,7 +7,7 @@ import { lineString as turfLineString } from '@turf/helpers';
 import turfLineIntersect from "@turf/line-intersect";
 
 import {
-  LINE_MODES, DEFAULT_LINE_MODE, USER_ICONS, COLOR_TO_FILTER, SYSTEM_LEVELS, COLOR_TO_NAME, DEFAULT_LINES,
+  LINE_MODES, DEFAULT_LINE_MODE, LINE_THICKNESSES, USER_ICONS, COLOR_TO_FILTER, SYSTEM_LEVELS, COLOR_TO_NAME, DEFAULT_LINES,
   ACCESSIBLE, BICYCLE, BUS, CITY, CLOUD, FERRY,
   GONDOLA, METRO, PEDESTRIAN, SHUTTLE, TRAIN, TRAM, USER_BASIC, LINE_ICONS_PNG_DIR,
   LINE_ICON_SHAPE_SET, LINE_ICONS_SVG_DIR
@@ -20,6 +20,26 @@ export function getMode(key) {
   }, {});
 
   return modeObject[key || ''] ? modeObject[key || ''] : modeObject[DEFAULT_LINE_MODE];
+}
+
+// returns the render width multiplier for a line thickness key.
+// defaults to 1 (MEDIUM) for undefined/unknown keys, so lines without a
+// `thickness` field render at the original default width.
+export function getThicknessMult(thicknessKey) {
+  const match = LINE_THICKNESSES.find(t => t.key === thicknessKey);
+  return match ? match.multiplier : 1;
+}
+
+// returns a hex color darkened by the given factor (0-1). used to derive the
+// "slightly darker" secondary color shown in the gaps of a dashed line.
+export function darkenColor(hex, factor = 0.6) {
+  const rgb = hexToRGB(hex);
+  if (!rgb) return hex;
+  return rgbToHex({
+    R: Math.round(rgb.R * factor),
+    G: Math.round(rgb.G * factor),
+    B: Math.round(rgb.B * factor)
+  });
 }
 
 // returns a level object based on key, avgSpacing, or radius. key is prioritized.
@@ -571,6 +591,18 @@ export function getColoredIcon(line, fallback = '') {
   return coloredIcon;
 }
 
+// builds the visual-identity key for a line/pattern. lines sharing this key
+// merge into a single drawn stroke; differing keys render as parallel strokes
+// with their own offset. encodes color, icon, thickness multiplier, and dash
+// so thickness/dash differences produce visually distinct lines.
+// `pattern` accepts { color, icon, widthMult, dashed }.
+export function patternKey(pattern = {}) {
+  const icon = pattern.icon ? pattern.icon : 'solid';
+  const widthMult = pattern.widthMult != null ? pattern.widthMult : 1;
+  const dash = pattern.dashed ? 'dash' : 'nodash';
+  return `${pattern.color}|${icon}|${widthMult}|${dash}`;
+}
+
 // check if the two target stationIds appear adjacent to one another in target line
 // a station may appear >1 time in a line if there is a loop
 function _areAdjacentInLine(lineBeingChecked, currStationId, nextStationId) {
@@ -609,7 +641,9 @@ function _buildMiniInterlineSegments(lineKeys, system, ignoreIcon) {
     const line = system.lines[lineKey];
 
     const coloredIcon = ignoreIcon ? 'solid' : getColoredIcon(line, 'solid');
-    const linePattern = `${line.color}|${coloredIcon}`;
+    const lineWidthMult = getThicknessMult(line.thickness);
+    const lineDashed = !!line.dashed && coloredIcon === 'solid'; // dash only applies to non-icon lines
+    const linePattern = patternKey({ color: line.color, icon: coloredIcon, widthMult: lineWidthMult, dashed: lineDashed });
 
     if (!line || !line.stationIds?.length) continue;
 
@@ -639,7 +673,9 @@ function _buildMiniInterlineSegments(lineKeys, system, ignoreIcon) {
 
         const lineBeingChecked = system.lines[lineKeyBeingChecked];
         const lineBeingCheckedPatternedIcon = ignoreIcon ? 'solid' : getColoredIcon(lineBeingChecked, 'solid');
-        const lineBeingCheckedPattern = `${lineBeingChecked.color}|${lineBeingCheckedPatternedIcon}`;
+        const lineBeingCheckedWidthMult = getThicknessMult(lineBeingChecked.thickness);
+        const lineBeingCheckedDashed = !!lineBeingChecked.dashed && lineBeingCheckedPatternedIcon === 'solid';
+        const lineBeingCheckedPattern = patternKey({ color: lineBeingChecked.color, icon: lineBeingCheckedPatternedIcon, widthMult: lineBeingCheckedWidthMult, dashed: lineBeingCheckedDashed });
 
         if (linePattern !== lineBeingCheckedPattern) { // don't bother checking lines with the same color
           let patternsInSegment = [ linePattern ];
@@ -673,16 +709,21 @@ function _calculateOffsets(patterns, thickness) {
   const centered = patterns.length % 2 === 1; // center if odd number of lines
   let moveNegative = false;
 
+  // widen the spacing unit to the thickest line in the segment so thicker
+  // parallel lines don't overlap. when every line is the default width this
+  // equals `thickness`, leaving existing maps' offsets unchanged.
+  const maxMult = Math.max(1, ...patterns.map(p => p.widthMult != null ? p.widthMult : 1));
+  const displacement = thickness * maxMult;
+
   for (const [ind, pattern] of patterns.entries()) {
-    const displacement = thickness;
     let offsetDistance = 0;
     if (centered) {
       offsetDistance = Math.floor((ind + 1) / 2) * displacement;
     } else {
-      offsetDistance = (thickness / 2) + (Math.floor((ind) / 2) * displacement);
+      offsetDistance = (displacement / 2) + (Math.floor((ind) / 2) * displacement);
     }
 
-    offsets[`${pattern.color}|${pattern.icon ? pattern.icon : 'solid'}`] = offsetDistance * (moveNegative ? -1 : 1);
+    offsets[patternKey(pattern)] = offsetDistance * (moveNegative ? -1 : 1);
     moveNegative = !moveNegative;
   }
 
@@ -732,12 +773,15 @@ function _accumulateInterlineSegments(miniInterlineSegmentsByColors, thickness, 
       let colors = colorsJoined.split('-');
       let colorConfigs = [];
       for (const [ind, color] of colors.entries()) {
+        // each token is `color|icon|widthMult|dashFlag` (see patternKey)
         const colorParts = color.split('|');
-        if (colorParts.length === 2 && colorParts[1] !== 'solid' && !ignoreIcon) {
-          colorConfigs.push({ color: colorParts[0], icon: colorParts[1] });
-        } else {
-          colorConfigs.push({ color: colorParts[0] });
+        const config = { color: colorParts[0] };
+        if (colorParts[1] && colorParts[1] !== 'solid' && !ignoreIcon) {
+          config.icon = colorParts[1];
         }
+        config.widthMult = colorParts[2] != null && colorParts[2] !== '' ? parseFloat(colorParts[2]) : 1;
+        config.dashed = colorParts[3] === 'dash';
+        colorConfigs.push(config);
       }
       accumulator = accumulator[0] > accumulator[accumulator.length - 1] ? accumulator : [...accumulator].reverse();
       interlineSegments[accumulator.join('|')] = {


### PR DESCRIPTION
## What does this add?

Enables 5 different options for line thickness:
Extra Thin, Thin, Default, Thick, Extra Thick
<img width="403" height="365" alt="image" src="https://github.com/user-attachments/assets/684004b4-d381-499a-b8e7-8de69fd80d2a" />

Also enables an optional dash pattern coloring for lines.
<img width="476" height="390" alt="image" src="https://github.com/user-attachments/assets/f31bbe64-d0f5-464f-acee-db831be6a50a" />

The new options appear in the menu for lines:
<img width="381" height="220" alt="image" src="https://github.com/user-attachments/assets/d3b24ef8-daef-49c5-8318-59f475dc4c50" />

## Why is this necessary?

Combined, these 2 options provide map makers with a greatly enhanced ability to beautify their maps. They can use different line thickness to differentiate between levels of service (ie metro versus primary bus network versus secondary bus network), and also use dashed lines to differentiate between different modes or simply to beautify their maps.

Here's an example of a map which would benefit greatly from a better ability to distinguish hierarchy of service levels and differentiate between modes:
<img width="963" height="588" alt="image" src="https://github.com/user-attachments/assets/b9055556-ab8e-4dfc-8cae-2005e943a654" />
https://metrodreamin.com/view/ajF6c0tRczhXSU5zbjQwNURTUGdNdEJONm1tMXww

contrast that with a clear visual hierarchy we can achieve like this:
<img width="690" height="440" alt="image" src="https://github.com/user-attachments/assets/32bc5ad9-b8a6-4e4b-9369-1aef4a331dfa" />
with dashed pattern and thicker line for the train, regular line thickness for BRT, thin line for local bus route

## Testing

 So far, I have only tested in local offline mode.

These additions should be backwards compatible with existing maps. But I haven't looked into what steps are necessary to test with the actual Firebase server or if that's even possible for external devs.